### PR TITLE
remove custom constructor because listener class is provided in doctrine config

### DIFF
--- a/src/Plugin/Doctrine/Domain/RemoveDeletedAggregatesListener.php
+++ b/src/Plugin/Doctrine/Domain/RemoveDeletedAggregatesListener.php
@@ -11,22 +11,6 @@ use Doctrine\ORM\Events;
 
 class RemoveDeletedAggregatesListener implements EventSubscriber
 {
-    /** @var EntityManagerInterface */
-    private $entityManager;
-
-    /**
-     * @param EntityManagerInterface $entityManager
-     */
-    public function __construct(EntityManagerInterface $entityManager)
-    {
-        $this->entityManager = $entityManager;
-
-        // Subscribe itself with doctrine event manager
-        /** @var EventManager $eventManager */
-        $eventManager = $this->entityManager->getEventManager();
-        $eventManager->addEventSubscriber($this);
-    }
-
     /**
      * @return array
      */


### PR DESCRIPTION
… and subscribed in entity manager factory
